### PR TITLE
Fix rspec to integrate with jsonapi_errors_handler

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,12 @@ class ApplicationController < ActionController::API
 
   include JsonapiErrorsHandler
 
-  # ErrorMapper.map_errors!({
-  #   "ActiveRecord::RecordNotFound" => "JsonapiErrorsHandler::Errors::NotFound",
-  #   "ActiveRecord::ActiveRecord::RecordInvalid" => "JsonapiErrorsHandler::Errors::Invalid",
-  # })
+  ErrorMapper.map_errors!({
+    "ActiveRecord::RecordNotFound" => "JsonapiErrorsHandler::Errors::NotFound",
+    "ActiveRecord::ActiveRecord::RecordInvalid" => "JsonapiErrorsHandler::Errors::Invalid",
+    "UserAuthenticator::AuthenticationError" => "JsonapiErrorsHandler::Errors::Unauthorized",
+    "ApplicationController::AuthorizationError" => "JsonapiErrorsHandler::Errors::Forbidden"
+  })
   rescue_from ::StandardError, with: lambda { |e| handle_error(e) }
   rescue_from UserAuthenticator::AuthenticationError, with: lambda { |e| handle_error(e) }
   rescue_from AuthorizationError, with: lambda { |e| handle_error(e) }

--- a/spec/controllers/access_tokens_controller_spec.rb
+++ b/spec/controllers/access_tokens_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AccessTokensController, type: :controller do
       subject { post :create }
       it_behaves_like "unauthorized_requests"
     end
+
     context "when invalid code provided" do
       let(:github_error) {
         double("Sawyer::Resource", error: "bad_verification_code")

--- a/spec/support/shared/json_errors.rb
+++ b/spec/support/shared/json_errors.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 shared_examples_for "unauthorized_requests" do
   let(:authentication_error) do
     {
-      "status" => "401",
-      "source" => { "pointer" => "/code" },
-      "title" => "Authentication code is invalid",
-      "detail" => "You must provide valid code in order to exchange it for token.",
+      "status" => 401,
+      "source" => { "pointer" => "/request/headers/authorization" },
+      "title" => "Unauthorized",
+      "detail" => "You need to login to authorize this request.",
     }
   end
 
@@ -23,12 +23,13 @@ end
 shared_examples_for "forbidden_requests" do
   let(:authorization_error) do
     {
-      "status" => "403",
-      "source" => { "pointer" => "/headers/authorization" },
-      "title" => "Not authorized",
-      "detail" => "You have no right to access this resource.",
+      "status" => 403,
+      "source" => {"pointer"=>"/request/headers/authorization"},
+      "title" => "Forbidden request",
+      "detail" => "You have no rights to access this resource",
     }
   end
+
   it "shoud return 403 status code" do
     subject
     expect(response).to have_http_status(:forbidden)


### PR DESCRIPTION
1. Add mapping for missing errors
2. Adjust the expectations messages to match the defaults from the gem.

To make it working with ANY messages, simply create your own error classes that inherit from `JsonapiErrorsHandler::Errors::StandardError`

https://github.com/driggl/jsonapi_errors_handler#localization-example

